### PR TITLE
support setting readability

### DIFF
--- a/Editor/Texture2DArrayImporter.cs
+++ b/Editor/Texture2DArrayImporter.cs
@@ -34,6 +34,9 @@ namespace Oddworm.EditorFramework
         [SerializeField]
         int m_AnisoLevel = 1;
 
+        [SerializeField]
+        bool m_Readable = false;
+
         [Tooltip("A list of textures that are added to the texture array.")]
         [SerializeField]
         List<Texture2D> m_Textures = new List<Texture2D>();
@@ -103,6 +106,12 @@ namespace Oddworm.EditorFramework
             set { m_AnisoLevel = value; }
         }
 
+        public bool readable
+        {
+            get { return m_Readable; }
+            set { m_Readable = value; }
+        }
+
         /// <summary>
         /// The file extension used for Texture2DArray assets without leading dot.
         /// </summary>
@@ -142,7 +151,7 @@ namespace Oddworm.EditorFramework
             // Create the texture array.
             // When the texture array asset is being created, there are no input textures added yet,
             // thus we do Max(1, Count) to make sure to add at least 1 slice.
-            var texture2DArray = new Texture2DArray(width, height, Mathf.Max(1, m_Textures.Count), textureFormat, mipmapEnabled, !srgbTexture);
+            var texture2DArray = new Texture2DArray(width, height, Mathf.Max(1, m_Textures.Count), textureFormat, mipmapEnabled, !srgbTexture, m_Readable);
             texture2DArray.wrapMode = m_WrapMode;
             texture2DArray.filterMode = m_FilterMode;
             texture2DArray.anisoLevel = m_AnisoLevel;

--- a/Editor/Texture2DArrayImporter.cs
+++ b/Editor/Texture2DArrayImporter.cs
@@ -151,7 +151,7 @@ namespace Oddworm.EditorFramework
             // Create the texture array.
             // When the texture array asset is being created, there are no input textures added yet,
             // thus we do Max(1, Count) to make sure to add at least 1 slice.
-            var texture2DArray = new Texture2DArray(width, height, Mathf.Max(1, m_Textures.Count), textureFormat, mipmapEnabled, !srgbTexture, m_Readable);
+            var texture2DArray = new Texture2DArray(width, height, Mathf.Max(1, m_Textures.Count), textureFormat, mipmapEnabled, !srgbTexture);
             texture2DArray.wrapMode = m_WrapMode;
             texture2DArray.filterMode = m_FilterMode;
             texture2DArray.anisoLevel = m_AnisoLevel;
@@ -212,6 +212,7 @@ namespace Oddworm.EditorFramework
             var buildTarget = ctx.selectedBuildTarget;
 #endif
 
+            texture2DArray.Apply(false, !m_Readable);
             ctx.AddObjectToAsset("Texture2DArray", texture2DArray);
             ctx.SetMainObject(texture2DArray);
 

--- a/Editor/Texture2DArrayImporterInspector.cs
+++ b/Editor/Texture2DArrayImporterInspector.cs
@@ -32,6 +32,7 @@ namespace Oddworm.EditorFramework
             public readonly GUIContent wrapModeLabel = new GUIContent("Wrap Mode", "Select how the Texture behaves when tiled.");
             public readonly GUIContent filterModeLabel = new GUIContent("Filter Mode", "Select how the Texture is filtered when it gets stretched by 3D transformations.");
             public readonly GUIContent anisoLevelLabel = new GUIContent("Aniso Level", "Increases Texture quality when viewing the Texture at a steep angle. Good for floor and ground Textures.");
+            public readonly GUIContent readableLabel = new GUIContent("Readable", "Enable to be able to access the texture data from scripts.");
             public readonly GUIContent anisotropicFilteringDisable = new GUIContent("Anisotropic filtering is disabled for all textures in Quality Settings.");
             public readonly GUIContent anisotropicFilteringForceEnable = new GUIContent("Anisotropic filtering is enabled for all textures in Quality Settings.");
             public readonly GUIContent texturesHeaderLabel = new GUIContent("Textures", "Drag&drop one or multiple textures here to add them to the list.");
@@ -51,6 +52,7 @@ namespace Oddworm.EditorFramework
         SerializedProperty m_WrapMode = null;
         SerializedProperty m_FilterMode = null;
         SerializedProperty m_AnisoLevel = null;
+        SerializedProperty m_Readable = null;
         SerializedProperty m_Textures = null;
         ReorderableList m_TextureList = null;
 
@@ -66,6 +68,7 @@ namespace Oddworm.EditorFramework
             m_WrapMode = serializedObject.FindProperty("m_WrapMode");
             m_FilterMode = serializedObject.FindProperty("m_FilterMode");
             m_AnisoLevel = serializedObject.FindProperty("m_AnisoLevel");
+            m_Readable = serializedObject.FindProperty("m_Readable");
             m_Textures = serializedObject.FindProperty("m_Textures");
 
             m_TextureList = new ReorderableList(serializedObject, m_Textures);
@@ -90,6 +93,7 @@ namespace Oddworm.EditorFramework
             EditorGUILayout.PropertyField(m_WrapMode, styles.wrapModeLabel);
             EditorGUILayout.PropertyField(m_FilterMode, styles.filterModeLabel);
             EditorGUILayout.PropertyField(m_AnisoLevel, styles.anisoLevelLabel);
+            EditorGUILayout.PropertyField(m_Readable, styles.readableLabel);
 
             // If Aniso is used, check quality settings and displays some info.
             // I've only added this, because Unity is doing it in the Texture Inspector as well.


### PR DESCRIPTION
A newly created texture2darray is readable by default, so I add 'm_Readable' to be able to make textures consume less memory if we don't need the system-memory copy after texture is uploaded to GPU.