### PR TITLE
support setting readability

### DIFF
--- a/Editor/Texture2DArrayImporter.cs
+++ b/Editor/Texture2DArrayImporter.cs
@@ -34,6 +34,9 @@ namespace Oddworm.EditorFramework
         [SerializeField]
         int m_AnisoLevel = 1;
 
+        [SerializeField]
+        bool m_Readable = false;
+
         [Tooltip("A list of textures that are added to the texture array.")]
         [SerializeField]
         List<Texture2D> m_Textures = new List<Texture2D>();
@@ -101,6 +104,12 @@ namespace Oddworm.EditorFramework
         {
             get { return m_AnisoLevel; }
             set { m_AnisoLevel = value; }
+        }
+
+        public bool readable
+        {
+            get { return m_Readable; }
+            set { m_Readable = value; }
         }
 
         /// <summary>
@@ -203,6 +212,7 @@ namespace Oddworm.EditorFramework
             var buildTarget = ctx.selectedBuildTarget;
 #endif
 
+            texture2DArray.Apply(false, !m_Readable);
             ctx.AddObjectToAsset("Texture2DArray", texture2DArray);
             ctx.SetMainObject(texture2DArray);
 

--- a/Editor/Texture2DArrayImporterInspector.cs
+++ b/Editor/Texture2DArrayImporterInspector.cs
@@ -32,6 +32,7 @@ namespace Oddworm.EditorFramework
             public readonly GUIContent wrapModeLabel = new GUIContent("Wrap Mode", "Select how the Texture behaves when tiled.");
             public readonly GUIContent filterModeLabel = new GUIContent("Filter Mode", "Select how the Texture is filtered when it gets stretched by 3D transformations.");
             public readonly GUIContent anisoLevelLabel = new GUIContent("Aniso Level", "Increases Texture quality when viewing the Texture at a steep angle. Good for floor and ground Textures.");
+            public readonly GUIContent readableLabel = new GUIContent("Readable", "Enable to be able to access the texture data from scripts.");
             public readonly GUIContent anisotropicFilteringDisable = new GUIContent("Anisotropic filtering is disabled for all textures in Quality Settings.");
             public readonly GUIContent anisotropicFilteringForceEnable = new GUIContent("Anisotropic filtering is enabled for all textures in Quality Settings.");
             public readonly GUIContent texturesHeaderLabel = new GUIContent("Textures", "Drag&drop one or multiple textures here to add them to the list.");
@@ -51,6 +52,7 @@ namespace Oddworm.EditorFramework
         SerializedProperty m_WrapMode = null;
         SerializedProperty m_FilterMode = null;
         SerializedProperty m_AnisoLevel = null;
+        SerializedProperty m_Readable = null;
         SerializedProperty m_Textures = null;
         ReorderableList m_TextureList = null;
 
@@ -66,6 +68,7 @@ namespace Oddworm.EditorFramework
             m_WrapMode = serializedObject.FindProperty("m_WrapMode");
             m_FilterMode = serializedObject.FindProperty("m_FilterMode");
             m_AnisoLevel = serializedObject.FindProperty("m_AnisoLevel");
+            m_Readable = serializedObject.FindProperty("m_Readable");
             m_Textures = serializedObject.FindProperty("m_Textures");
 
             m_TextureList = new ReorderableList(serializedObject, m_Textures);
@@ -90,6 +93,7 @@ namespace Oddworm.EditorFramework
             EditorGUILayout.PropertyField(m_WrapMode, styles.wrapModeLabel);
             EditorGUILayout.PropertyField(m_FilterMode, styles.filterModeLabel);
             EditorGUILayout.PropertyField(m_AnisoLevel, styles.anisoLevelLabel);
+            EditorGUILayout.PropertyField(m_Readable, styles.readableLabel);
 
             // If Aniso is used, check quality settings and displays some info.
             // I've only added this, because Unity is doing it in the Texture Inspector as well.


### PR DESCRIPTION
A newly created texture2darray is readable by default, the bad thing is, readable textures will keep a copy of texture data in memory to support functions like Get/SetPixels, but most of the time we don't need them at all. So It might be useful to support non-readable texture2darray. unity will serialize the 'readable' field automatically after calling texture2DArray.Apply(bool updateMipmaps, bool makeNoLongerReadable), and this api is compatible with most of the released unity versions.